### PR TITLE
调整一个函数的参数，以适应新版本的fgsea

### DIFF
--- a/R/gseMeSH.R
+++ b/R/gseMeSH.R
@@ -7,9 +7,10 @@
 ##' @param database one of 'gendoo', 'gene2pubmed' or 'RBBH'
 ##' @param category one of "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L","M", "N", "V", "Z"
 ##' @param exponent weight of each step
+##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
-##' @param eps_dose This parameter sets the boundary for calculating the p value.
+##' @param eps This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue Cutoff
 ##' @param pAdjustMethod pvalue adjustment method
 ##' @param verbose print message or not
@@ -29,10 +30,10 @@ gseMeSH <- function(geneList,
                     database = 'gendoo',
                     category = 'C',
                     exponent      = 1,
-                    #nPerm         = 1000,
+                    nPerm         = 1000,
                     minGSSize     = 10,
                     maxGSSize     = 500,
-                    eps_dose      = 1e-10,
+                    eps      = 1e-10,
                     pvalueCutoff=0.05,
                     pAdjustMethod="BH",
                     verbose       = TRUE,
@@ -40,18 +41,33 @@ gseMeSH <- function(geneList,
                     by = 'fgsea') {
 
     MeSH_DATA <- get_MeSH_data(MeSHDb, database, category)
-    res <-  GSEA_internal(geneList = geneList,
-                          exponent = exponent,
-                          #nPerm = nPerm,
-                          minGSSize = minGSSize,
-                          maxGSSize = maxGSSize,
-                          eps_dose = eps_dose,
-                          pvalueCutoff = pvalueCutoff,
-                          pAdjustMethod = pAdjustMethod,
-                          verbose = verbose,
-                          USER_DATA = MeSH_DATA,
-                          seed = seed,
-                          by = by)
+    
+    if(missing(nPerm)) {
+        res <-  GSEA_internal(geneList         = geneList,
+                              exponent         = exponent,
+                              minGSSize        = minGSSize,
+                              maxGSSize        = maxGSSize,
+                              eps              = eps,
+                              pvalueCutoff     = pvalueCutoff,
+                              pAdjustMethod    = pAdjustMethod,
+                              verbose          = verbose,
+                              USER_DATA        = MeSH_DATA,
+                              seed             = seed,
+                              by               = by)
+    } else {
+        res <-  GSEA_internal(geneList         = geneList,
+                              exponent         = exponent,
+                              nPerm            = nPerm,
+                              minGSSize        = minGSSize,
+                              maxGSSize        = maxGSSize,
+                              pvalueCutoff     = pvalueCutoff,
+                              pAdjustMethod    = pAdjustMethod,
+                              verbose          = verbose,
+                              USER_DATA        = MeSH_DATA,
+                              seed             = seed,
+                              by               = by)
+    }
+    
 
     meshdb <- get_fun_from_pkg("MeSH.db", "MeSH.db")
     id <- res@result$ID

--- a/R/gseMeSH.R
+++ b/R/gseMeSH.R
@@ -15,7 +15,6 @@
 ##' @param verbose print message or not
 ##' @param seed logical
 ##' @param by one of 'fgsea' or 'DOSE'
-##' @param by one of 'fgsea' or 'DOSE'
 ##' @param ... other parameter
 ##' @importClassesFrom DOSE gseaResult
 ##' @export

--- a/R/gseMeSH.R
+++ b/R/gseMeSH.R
@@ -7,9 +7,9 @@
 ##' @param database one of 'gendoo', 'gene2pubmed' or 'RBBH'
 ##' @param category one of "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L","M", "N", "V", "Z"
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
+##' @param eps_dose This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue Cutoff
 ##' @param pAdjustMethod pvalue adjustment method
 ##' @param verbose print message or not
@@ -29,9 +29,10 @@ gseMeSH <- function(geneList,
                     database = 'gendoo',
                     category = 'C',
                     exponent      = 1,
-                    nPerm         = 1000,
+                    #nPerm         = 1000,
                     minGSSize     = 10,
                     maxGSSize     = 500,
+                    eps_dose      = 1e-10,
                     pvalueCutoff=0.05,
                     pAdjustMethod="BH",
                     verbose       = TRUE,
@@ -41,9 +42,10 @@ gseMeSH <- function(geneList,
     MeSH_DATA <- get_MeSH_data(MeSHDb, database, category)
     res <-  GSEA_internal(geneList = geneList,
                           exponent = exponent,
-                          nPerm = nPerm,
+                          #nPerm = nPerm,
                           minGSSize = minGSSize,
                           maxGSSize = maxGSSize,
+                          eps_dose = eps_dose,
                           pvalueCutoff = pvalueCutoff,
                           pAdjustMethod = pAdjustMethod,
                           verbose = verbose,

--- a/R/gseMeSH.R
+++ b/R/gseMeSH.R
@@ -7,7 +7,6 @@
 ##' @param database one of 'gendoo', 'gene2pubmed' or 'RBBH'
 ##' @param category one of "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L","M", "N", "V", "Z"
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @param eps This parameter sets the boundary for calculating the p value.
@@ -16,6 +15,8 @@
 ##' @param verbose print message or not
 ##' @param seed logical
 ##' @param by one of 'fgsea' or 'DOSE'
+##' @param by one of 'fgsea' or 'DOSE'
+##' @param ... other parameter
 ##' @importClassesFrom DOSE gseaResult
 ##' @export
 ##' @return gseaResult object
@@ -27,46 +28,33 @@
 ##' @author Yu Guangchuang
 gseMeSH <- function(geneList,
                     MeSHDb,
-                    database = 'gendoo',
-                    category = 'C',
+                    database      = 'gendoo',
+                    category      = 'C',
                     exponent      = 1,
-                    nPerm         = 1000,
                     minGSSize     = 10,
                     maxGSSize     = 500,
-                    eps      = 1e-10,
-                    pvalueCutoff=0.05,
-                    pAdjustMethod="BH",
+                    eps           = 1e-10,
+                    pvalueCutoff  =0.05,
+                    pAdjustMethod ="BH",
                     verbose       = TRUE,
                     seed          = FALSE,
-                    by = 'fgsea') {
+                    by            = 'fgsea',
+                    ...) {
 
     MeSH_DATA <- get_MeSH_data(MeSHDb, database, category)
     
-    if(missing(nPerm)) {
-        res <-  GSEA_internal(geneList         = geneList,
-                              exponent         = exponent,
-                              minGSSize        = minGSSize,
-                              maxGSSize        = maxGSSize,
-                              eps              = eps,
-                              pvalueCutoff     = pvalueCutoff,
-                              pAdjustMethod    = pAdjustMethod,
-                              verbose          = verbose,
-                              USER_DATA        = MeSH_DATA,
-                              seed             = seed,
-                              by               = by)
-    } else {
-        res <-  GSEA_internal(geneList         = geneList,
-                              exponent         = exponent,
-                              nPerm            = nPerm,
-                              minGSSize        = minGSSize,
-                              maxGSSize        = maxGSSize,
-                              pvalueCutoff     = pvalueCutoff,
-                              pAdjustMethod    = pAdjustMethod,
-                              verbose          = verbose,
-                              USER_DATA        = MeSH_DATA,
-                              seed             = seed,
-                              by               = by)
-    }
+    res <-  GSEA_internal(geneList         = geneList,
+                          exponent         = exponent,
+                          minGSSize        = minGSSize,
+                          maxGSSize        = maxGSSize,
+                          eps              = eps,
+                          pvalueCutoff     = pvalueCutoff,
+                          pAdjustMethod    = pAdjustMethod,
+                          verbose          = verbose,
+                          USER_DATA        = MeSH_DATA,
+                          seed             = seed,
+                          by               = by,
+                          ...)
     
 
     meshdb <- get_fun_from_pkg("MeSH.db", "MeSH.db")

--- a/man/gseMeSH.Rd
+++ b/man/gseMeSH.Rd
@@ -10,9 +10,10 @@ gseMeSH(
   database = "gendoo",
   category = "C",
   exponent = 1,
+  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
-  eps_dose = 1e-10,
+  eps = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -31,11 +32,13 @@ gseMeSH(
 
 \item{exponent}{weight of each step}
 
+\item{nPerm}{permutation numbers}
+
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
 
-\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
+\item{eps}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseMeSH.Rd
+++ b/man/gseMeSH.Rd
@@ -10,7 +10,6 @@ gseMeSH(
   database = "gendoo",
   category = "C",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
   eps = 1e-10,
@@ -18,7 +17,8 @@ gseMeSH(
   pAdjustMethod = "BH",
   verbose = TRUE,
   seed = FALSE,
-  by = "fgsea"
+  by = "fgsea",
+  ...
 )
 }
 \arguments{
@@ -31,8 +31,6 @@ gseMeSH(
 \item{category}{one of "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L","M", "N", "V", "Z"}
 
 \item{exponent}{weight of each step}
-
-\item{nPerm}{permutation numbers}
 
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
@@ -49,6 +47,8 @@ gseMeSH(
 \item{seed}{logical}
 
 \item{by}{one of 'fgsea' or 'DOSE'}
+
+\item{...}{other parameter}
 }
 \value{
 gseaResult object

--- a/man/gseMeSH.Rd
+++ b/man/gseMeSH.Rd
@@ -10,9 +10,9 @@ gseMeSH(
   database = "gendoo",
   category = "C",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
+  eps_dose = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -31,11 +31,11 @@ gseMeSH(
 
 \item{exponent}{weight of each step}
 
-\item{nPerm}{permutation numbers}
-
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
+
+\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 


### PR DESCRIPTION
对调用了fgsea的函数进行了升级，去掉了 `nPerm` 参数，增加了 `eps_dose` 参数。
调用关系为：
GSEA_internal被 gseMeSH 调用